### PR TITLE
Don't fail on empty YAML config

### DIFF
--- a/staticconf/loader.py
+++ b/staticconf/loader.py
@@ -78,7 +78,7 @@ def build_loader(loader_func):
 def yaml_loader(filename):
     import yaml
     with open(filename) as fh:
-        return yaml.load(fh)
+        return yaml.load(fh) or {}
 
 def json_loader(filename):
     try:


### PR DESCRIPTION
It should be valid for a config file to be present but empty, for example when all defined options have default values.

`yaml.load` returns `None` if the file is empty, but staticconf expects an iterable. This fix returns `{}` if `yaml.load` would return `None`.
