### PR TITLE
0.5.2 only hold weakref to proxies.

### DIFF
--- a/staticconf/__init__.py
+++ b/staticconf/__init__.py
@@ -3,7 +3,7 @@ from staticconf.loader import *
 from staticconf.getters import *
 
 
-version         = "0.5.1"
+version         = "0.5.2"
 
 view_help       = config.view_help
 reload          = config.reload

--- a/staticconf/proxy.py
+++ b/staticconf/proxy.py
@@ -94,7 +94,14 @@ def extract_value(proxy):
 
 class ValueProxy(object):
     """Proxy a configuration value so it can be loaded after import time."""
-    __slots__ = ['validator', 'config_key', 'default', '_value', 'namespace']
+    __slots__ = [
+        'validator',
+        'config_key',
+        'default',
+        '_value',
+        'namespace',
+        '__weakref__'
+    ]
 
     @classmethod
     @cache_as_field('_class_def')

--- a/staticconf/schema.py
+++ b/staticconf/schema.py
@@ -69,7 +69,14 @@ class ValueTypeDefinition(object):
 
 
 class ValueToken(object):
-    __slots__ = ['validator', 'config_key', 'default', '_value', 'namespace']
+    __slots__ = [
+        'validator',
+        'config_key',
+        'default',
+        '_value',
+        'namespace',
+        '__weakref__'
+    ]
 
     def __init__(self, validator, namespace, key, default):
         self.validator      = validator


### PR DESCRIPTION
This should allow staticconf.getters to be used non-statically without leaking proxies.
