### PR TITLE
Use C-based YAML parser when available

### DIFF
--- a/staticconf/loader.py
+++ b/staticconf/loader.py
@@ -86,7 +86,7 @@ def yaml_loader(filename):
         from yaml import CLoader as Loader
     except ImportError:
         from yaml import Loader
-        
+
     with open(filename) as fh:
         return yaml.load(fh, Loader=Loader) or {}
 


### PR DESCRIPTION
Taken from the top of http://pyyaml.org/wiki/PyYAMLDocumentation

Seems to be about 10× faster.
