### PR TITLE
Adapted PyPy check to use platform.python_implementation

### DIFF
--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -1,6 +1,6 @@
 import gc
 import os
-import sys
+import platform
 import tempfile
 import time
 
@@ -72,7 +72,7 @@ class TestConfigurationNamespace(object):
             self.namespace.register_proxy(mock_proxy)
         assert_equal(self.namespace.get_value_proxies(), proxies)
 
-    @pytest.mark.skipif('PyPy' in sys.version, reason="Fails on PyPy")
+    @pytest.mark.skipif('PyPy' in platform.python_implementation(), reason="Fails on PyPy")
     def test_get_value_proxies_does_not_contain_out_of_scope_proxies(self):
         assert not self.namespace.get_value_proxies()
         def a_scope():


### PR DESCRIPTION
The string `sys.version` should not be used for any version / platform comparisons as there are no guarantees on its contents. Instead the value of [`platform.python_implementation()`](https://docs.python.org/2/library/platform.html#platform.python_implementation) should be used.
