### PR TITLE
Refactor config watcher

### DIFF
--- a/.pyautotest
+++ b/.pyautotest
@@ -3,4 +3,5 @@ command:
     - 'py.test'
     - '-v'
     - '-s'
+    - '--tb=short'
     - tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,14 @@
 language: python
+env:
+- TOX_ENV=py26
+- TOX_ENV=py27
+- TOX_ENV=py33
+- TOX_ENV=py34
+- TOX_ENV=pypy
+- TOX_ENV=docs
+- TOX_ENV=coverage
+
 install:
-    - pip install tox
-    - pip install coveralls
-script: tox
+    - pip install --use-mirrors tox coveralls
+script: tox -e $TOX_ENV
 after_success: coveralls

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
-.PHONY: clean docs testi upload
+.PHONY: clean docs test upload
 
 
 clean:

--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -3,9 +3,18 @@ Config
 ======
 
 .. automodule:: staticconf.config
-    :members: ConfigNamespace, get_namespace, validate, view_help, 
-              ConfigurationWatcher, ReloadCallbackChain, ConfigFacade,
-              reload
+    :members: ConfigNamespace,
+        get_namespace,
+        validate,
+        view_help,
+        ConfigurationWatcher,
+        IComparator,
+        InodeComparator,
+        MTimeComparator,
+        MD5Comparator,
+        ReloadCallbackChain,
+        ConfigFacade,
+        reload
 
 Errors
 ------

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,3 @@ pyyaml
 pytest
 mock
 flake8
-
-# Doc requirements
-sphinx_rtd_theme
-sphinx

--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -12,6 +12,7 @@ These classes provide a way of reloading configuration when the file is
 modified.
 """
 from collections import namedtuple
+import hashlib
 import logging
 import os
 import time
@@ -295,26 +296,33 @@ class ConfigurationWatcher(object):
 
 
     :param config_loader: a function which takes no arguments. It is called
-                          by :func:`reload_if_changed` if the file has
-                          been modified
+        by :func:`reload_if_changed` if the file has been modified
     :param filenames: a filename or list of filenames to watch for modifications
     :param min_interval: minimum number of seconds to wait between calls to
-                         :func:`os.path.getmtime` to check if a file has
-                         been modified.
-
+        :func:`os.path.getmtime` to check if a file has been modified.
     :param reloader: a function which is called after `config_loader` when a
-                     file has been modified. Defaults to an empty
-                     :class:`ReloadCallbackChain`
+        file has been modified. Defaults to an empty
+        :class:`ReloadCallbackChain`
+    :param comparators: a list of classes which support the
+        :class:`IComparator` interface which are used to determine if a config
+        file has been modified. Defaults to :class:`InodeComparator` and
+        :class:`MTimeComparator`.
     """
 
-    def __init__(self, config_loader, filenames, min_interval=0, reloader=None):
+    def __init__(
+            self,
+            config_loader,
+            filenames,
+            min_interval=0,
+            reloader=None,
+            comparators=None):
         self.config_loader  = config_loader
         self.filenames      = self.get_filename_list(filenames)
-        self.inodes         = self._get_inodes()
         self.min_interval   = min_interval
         self.last_check     = time.time()
-        self.last_max_mtime = self.most_recent_changed
         self.reloader       = reloader or ReloadCallbackChain(all_names=True)
+        comparators         = comparators or [InodeComparator, MTimeComparator]
+        self.comparators    = [comp(self.filenames) for comp in comparators]
 
     def get_filename_list(self, filenames):
         if isinstance(filenames, six.string_types):
@@ -325,32 +333,21 @@ class ConfigurationWatcher(object):
     def should_check(self):
         return self.last_check + self.min_interval <= time.time()
 
-    @property
-    def most_recent_changed(self):
-        return max(os.path.getmtime(name) for name in self.filenames)
-
-    def _get_inodes(self):
-        def get_inode(stbuf):
-            return stbuf.st_dev, stbuf.st_ino
-        return [get_inode(os.stat(filename)) for filename in self.filenames]
-
     def reload_if_changed(self, force=False):
         """If the file(s) being watched by this object have changed,
         their configuration will be loaded again using `config_loader`.
         Otherwise this is a noop.
 
-        :param force: If True ignore the modified time and force a reload
+        :param force: If True ignore the `min_interval` and proceed to
+            file modified comparisons.  To force a reload use
+            :func:`reload` directly.
         """
         if (force or self.should_check) and self.file_modified():
             return self.reload()
 
     def file_modified(self):
         self.last_check = time.time()
-        last_mtime, self.last_max_mtime = (
-                self.last_max_mtime, self.most_recent_changed)
-        last_inodes, self.inodes = self.inodes, self._get_inodes()
-        return (last_inodes != self.inodes or
-                last_mtime < self.last_max_mtime)
+        return any(comp.has_changed() for comp in self.comparators)
 
     def reload(self):
         config_dict = self.config_loader()
@@ -362,6 +359,90 @@ class ConfigurationWatcher(object):
 
     def load_config(self):
         return self.config_loader()
+
+
+class IComparator(object):
+    """Interface for a comparator which is used by :class:`ConfigurationWatcher`
+    to determine if a file has been modified since the last check. A comparator
+    is used to reduce the work required to reload configuration. Comparators
+    should implement a mechanism that is relatively efficient (and scalable),
+    so it can be performed frequently.
+
+    :param filenames: A list of absolute paths to configuration files.
+    """
+
+    def __init__(self, filenames):
+        pass
+
+    def has_changed(self):
+        """Returns True if any of the files have been modified since the last
+        call to :func:`has_changed`. Returns False otherwise.
+        """
+        pass
+
+
+class InodeComparator(object):
+    """Compare files by inode and device number. This is a good comparator to
+    use when your files can change multiple times per second.
+    """
+
+    def __init__(self, filenames):
+        self.filenames = filenames
+        self.inodes = self.get_inodes()
+
+    def get_inodes(self):
+        def get_inode(stbuf):
+            return stbuf.st_dev, stbuf.st_ino
+        return [get_inode(os.stat(filename)) for filename in self.filenames]
+
+    def has_changed(self):
+        last_inodes, self.inodes = self.inodes, self.get_inodes()
+        return last_inodes != self.inodes
+
+
+class MTimeComparator(object):
+    """Compare files by modified time.
+
+    .. note::
+
+        Most filesystems only store modified time with second grangularity
+        so multiple changes within the same second can be ignored.
+    """
+
+    def __init__(self, filenames):
+        self.filenames = filenames
+        self.last_max_mtime = self.get_most_recent_changed()
+
+    def get_most_recent_changed(self):
+        return max(os.path.getmtime(name) for name in self.filenames)
+
+    def has_changed(self):
+        last_mtime, self.last_max_mtime = (
+                self.last_max_mtime, self.get_most_recent_changed())
+        return last_mtime < self.last_max_mtime
+
+
+class MD5Comparator(object):
+    """Compare files by md5 hash of their contents. This comparator will be
+    slower for larger files, but is more resilient to modifications which only
+    change mtime, but not the files contents.
+    """
+
+    def __init__(self, filenames):
+        self.filenames = filenames
+        self.hashes = self.get_hashes()
+
+    def get_hashes(self):
+        def build_hash(filename):
+            hasher = hashlib.md5()
+            with open(filename) as fh:
+                hasher.update(fh.read())
+            return hasher.digest()
+        return map(build_hash, self.filenames)
+
+    def has_changed(self):
+        last_hashes, self.hashes = self.hashes, self.get_hashes()
+        return last_hashes != self.hashes
 
 
 class ReloadCallbackChain(object):
@@ -474,10 +555,5 @@ class ConfigFacade(object):
         self.callback_chain.add(identifier, callback)
 
     def reload_if_changed(self, force=False):
-        """If the files being watched by this object have changed,
-        their configuration will be loaded again using `loader_func`. Otherwise
-        this is a noop.
-
-        :param force: If True ignore the modified time and force a reload
-        """
+        """See :func:`ConfigurationWatcher.reload_if_changed` """
         self.watcher.reload_if_changed(force=force)

--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -435,10 +435,10 @@ class MD5Comparator(object):
     def get_hashes(self):
         def build_hash(filename):
             hasher = hashlib.md5()
-            with open(filename) as fh:
+            with open(filename, 'rb') as fh:
                 hasher.update(fh.read())
             return hasher.digest()
-        return map(build_hash, self.filenames)
+        return [build_hash(filename) for filename in self.filenames]
 
     def has_changed(self):
         last_hashes, self.hashes = self.hashes, self.get_hashes()

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -354,7 +354,8 @@ class TestConfigurationWatcher(object):
         assert self.watcher.should_check
 
     def test_file_modified_not_modified(self):
-        self.watcher.last_max_mtime = self.mock_path.getmtime.return_value = 222
+        self.watcher.comparators[1].last_max_mtime = mtime = 222
+        self.mock_path.getmtime.return_value = mtime
         self.mock_time.time.return_value = 123456
         assert not self.watcher.file_modified()
         assert_equal(self.watcher.last_check, self.mock_time.time.return_value)
@@ -367,8 +368,8 @@ class TestConfigurationWatcher(object):
         assert_equal(self.watcher.last_check, self.mock_time.time.return_value)
 
     def test_file_modified_moved(self):
-        self.mock_path.getmtime.return_value = 123456
-        self.watcher.last_max_mtime = 123456
+        self.mock_path.getmtime.return_value = mtime = 123456
+        self.watcher.comparators[1].last_max_mtime = mtime
         assert not self.watcher.file_modified()
         self.mock_stat.return_value.st_ino = 3
         assert self.watcher.file_modified()
@@ -399,7 +400,7 @@ class TestMD5Comparator(object):
 
     @pytest.yield_fixture()
     def comparator(self):
-        self.original_contents = "abcdefghijkabcd"
+        self.original_contents = b"abcdefghijkabcd"
         with tempfile.NamedTemporaryFile() as self.file:
             self.write_contents(self.original_contents)
             yield config.MD5Comparator([self.file.name])
@@ -416,7 +417,7 @@ class TestMD5Comparator(object):
 
     def test_has_changed_with_changes(self, comparator):
         assert not comparator.has_changed()
-        self.write_contents("this is the new content")
+        self.write_contents(b"this is the new content")
         assert comparator.has_changed()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33,py34,pypy,coverage
+envlist = py26,py27,py33,py34,pypy,docs,coverage
 
 [testenv]
 deps =


### PR DESCRIPTION
Factored out the `IComparator` interface, and added anew `MD5Comparator`.

We can use this instead of the mtime/inode comparators.

The comparators are pretty similar right now. They could be refactored to just be a single method that gets passed to a factory, but with only three of them I'm not sure that it's worth it just yet.