### PR TITLE
Fix crash when tracking mtime of 0 files

### DIFF
--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -414,6 +414,8 @@ class MTimeComparator(object):
         self.last_max_mtime = self.get_most_recent_changed()
 
     def get_most_recent_changed(self):
+        if not self.filenames:
+            return -1
         return max(os.path.getmtime(name) for name in self.filenames)
 
     def has_changed(self):


### PR DESCRIPTION
Hit an issue today where a non-existent config file was causing;

    ...
    return max(os.path.getmtime(name) for name in self.filenames)
    ValueError: max() arg is an empty sequence