### PR TITLE
Add ConfigNamespace::get_config_dict

### DIFF
--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -101,6 +101,18 @@ class ConfigNamespace(object):
         """
         return self.configuration_values
 
+    def get_config_dict(self):
+        """Reconstruct the nested structure of this object's configuration
+        and return it as a dict.
+        """
+        config_dict = {}
+        for dotted_key, value in self.get_config_values().items():
+            subkeys = dotted_key.split('.')
+            d = config_dict
+            for key in subkeys:
+                d = d.setdefault(key, value if key == subkeys[-1] else {})
+        return config_dict
+
     def get_known_keys(self):
         return set(vproxy.config_key for vproxy in self.get_value_proxies())
 

--- a/staticconf/version.py
+++ b/staticconf/version.py
@@ -1,2 +1,2 @@
 
-version = "0.9.0"
+version = "0.9.1"

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -104,19 +104,25 @@ class TestConfigurationNamespace(object):
 
     def test_get_config_dict(self):
         self.namespace['one.two.three.four'] = 5
-        self.namespace['a.b'] = 'c'
+        self.namespace['one.two.three.five'] = 'six'
+        self.namespace['one.b.cats'] = [1, 2, 3]
+        self.namespace['a.two'] = 'c'
         self.namespace['first'] = True
         d = self.namespace.get_config_dict()
         assert_equal(d, {
             'one': {
+                'b': {
+                    'cats': [1, 2, 3],
+                },
                 'two': {
                     'three': {
                         'four': 5,
+                        'five': 'six',
                     },
                 },
             },
             'a': {
-                'b': 'c',
+                'two': 'c',
             },
             'first': True,
         })

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -102,6 +102,25 @@ class TestConfigurationNamespace(object):
         values = self.namespace.get_config_values()
         assert_equal(values, {'stars': 'foo'})
 
+    def test_get_config_dict(self):
+        self.namespace['one.two.three.four'] = 5
+        self.namespace['a.b'] = 'c'
+        self.namespace['first'] = True
+        d = self.namespace.get_config_dict()
+        assert_equal(d, {
+            'one': {
+                'two': {
+                    'three': {
+                        'four': 5,
+                    },
+                },
+            },
+            'a': {
+                'b': 'c',
+            },
+            'first': True,
+        })
+
     def test_get_known_keys(self):
         proxies = [mock.Mock(), mock.Mock()]
         for mock_proxy in proxies:


### PR DESCRIPTION
I have found that occasionally I need access to the original nested structure of my configs and I don't want to reload them from their original source (e.g., my .yml files). This PR adds a function that builds this nested structure on demand.