### PR TITLE
Add new testing function PatchConfiguration

### DIFF
--- a/tests/testing_test.py
+++ b/tests/testing_test.py
@@ -22,3 +22,20 @@ class TestMockConfiguration(object):
         with testing.MockConfiguration(conf):
             assert_equal(staticconf.get('a.b'), 'two')
             assert_equal(staticconf.get('c'), 'three')
+
+
+class TestPatchConfiguration(object):
+
+    def test_nested(self):
+        with testing.MockConfiguration(a='one', b='two'):
+            with testing.PatchConfiguration(a='three'):
+                assert_equal(staticconf.get('a'), 'three')
+                assert_equal(staticconf.get('b'), 'two')
+
+            assert_equal(staticconf.get('a'), 'one')
+            assert_equal(staticconf.get('b'), 'two')
+
+    def test_not_nested(self):
+        with testing.PatchConfiguration(a='one', b='two'):
+            assert_equal(staticconf.get('a'), 'one')
+            assert_equal(staticconf.get('b'), 'two')


### PR DESCRIPTION
This creates a new way to mock out staticconf in tests. MockConfiguration only allows you to directly replace the entire namespace. However, PatchConfiguration patches the namespace preserving existing values. This allows you to mock out only a piece of the namespace, which can be useful for things like feature toggles.