### PR TITLE
by default, only reload for mtime changes, not inode changes

### DIFF
--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -317,8 +317,7 @@ class ConfigurationWatcher(object):
         :class:`ReloadCallbackChain`
     :param comparators: a list of classes which support the
         :class:`IComparator` interface which are used to determine if a config
-        file has been modified. Defaults to :class:`InodeComparator` and
-        :class:`MTimeComparator`.
+        file has been modified. Defaults to :class:`MTimeComparator`.
     """
 
     def __init__(
@@ -333,7 +332,7 @@ class ConfigurationWatcher(object):
         self.min_interval   = min_interval
         self.last_check     = time.time()
         self.reloader       = reloader or ReloadCallbackChain(all_names=True)
-        comparators         = comparators or [InodeComparator, MTimeComparator]
+        comparators         = comparators or [MTimeComparator]
         self.comparators    = [comp(self.filenames) for comp in comparators]
 
     def get_filename_list(self, filenames):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -379,25 +379,18 @@ class TestConfigurationWatcher(object):
         assert self.watcher.should_check
 
     def test_file_modified_not_modified(self):
-        self.watcher.comparators[1].last_max_mtime = mtime = 222
+        self.watcher.comparators[0].last_max_mtime = mtime = 222
         self.mock_path.getmtime.return_value = mtime
         self.mock_time.time.return_value = 123456
         assert not self.watcher.file_modified()
         assert_equal(self.watcher.last_check, self.mock_time.time.return_value)
 
     def test_file_modified(self):
-        self.watcher.comparators[1].last_max_mtime = 123456
+        self.watcher.comparators[0].last_max_mtime = 123456
         self.mock_path.getmtime.return_value = 123460
 
         assert self.watcher.file_modified()
         assert_equal(self.watcher.last_check, self.mock_time.time.return_value)
-
-    def test_file_modified_moved(self):
-        self.mock_path.getmtime.return_value = mtime = 123456
-        self.watcher.comparators[1].last_max_mtime = mtime
-        assert not self.watcher.file_modified()
-        self.mock_stat.return_value.st_ino = 3
-        assert self.watcher.file_modified()
 
     def test_reload_default(self):
         self.watcher.reload()


### PR DESCRIPTION
Hey there :-)

I'm trying to use mtimes as the sole source of versioning truth about whether a file has been updated, in order to reduce the number of reloads we do. I've applied the analogue of this patch to a bunch of localized callsites that construct `ConfigurationWatcher`, but I think it might make more sense if I changed the default, hence this PR.

The stated rationale for `InodeComparator` is "This is a good comparator to use when your files can change multiple times per second." I think this is not quite right: a file can be updated without its inode changing. (This probably wouldn't happen under a typical config deployment workflow, but then again, it's also unlikely that a file would change multiple times per second.) Anyway, this change supports a workflow where periodic inode change is unavoidable, but files can nevertheless signal "don't reload me" by preserving their old mtime.