### PR TITLE
Add support for logging MTimeComparator errors

### DIFF
--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -441,7 +441,9 @@ class MTimeComparator(object):
 
 def create_LoggingMTimeComparator(err_logger):
     """Return an MTimeComparator subclass that calls err_logger(filename)
-    if os.path.getmtime(filename) fails."""
+    if os.path.getmtime(filename) fails. err_logger is called within the
+    context of the raised OSError, thus sys.exc_info() can be used to
+    examine the exception."""
 
     def try_getmtime_else_log(filename):
         try:
@@ -451,8 +453,8 @@ def create_LoggingMTimeComparator(err_logger):
         return -1
 
     class LoggingMTimeComparator(MTimeComparator):
-        """Same as MTimeComparator but calls err_logger(filename)
-        if os.path.getmtime(filename) fails."""
+        """Same as MTimeComparator but calls err_logger(filename) in the
+        exception context if os.path.getmtime(filename) fails."""
 
         def get_most_recent_changed(self):
             if not self.filenames:

--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -443,21 +443,21 @@ def create_LoggingMTimeComparator(err_logger):
     """Return an MTimeComparator subclass that calls err_logger(filename)
     if os.path.getmtime(filename) fails."""
 
+    def try_getmtime_else_log(filename):
+        try:
+            return os.path.getmtime(filename)
+        except OSError:
+            err_logger(filename)
+        return -1
+
     class LoggingMTimeComparator(MTimeComparator):
         """Same as MTimeComparator but calls err_logger(filename)
         if os.path.getmtime(filename) fails."""
 
         def get_most_recent_changed(self):
-            max_time = -1
-            for filename in self.filenames:
-                try:
-                    time = os.path.getmtime(filename)
-                except OSError:
-                    err_logger(filename)
-                else:
-                    if time > max_time:
-                        max_time = time
-            return max_time
+            if not self.filenames:
+                return -1
+            return max(try_getmtime_else_log(name) for name in self.filenames)
 
     return LoggingMTimeComparator
 

--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -439,6 +439,29 @@ class MTimeComparator(object):
         return last_mtime < self.last_max_mtime
 
 
+def create_LoggingMTimeComparator(err_logger):
+    """Return an MTimeComparator subclass that calls err_logger(filename)
+    if os.path.getmtime(filename) fails."""
+
+    class LoggingMTimeComparator(MTimeComparator):
+        """Same as MTimeComparator but calls err_logger(filename)
+        if os.path.getmtime(filename) fails."""
+
+        def get_most_recent_changed(self):
+            max_time = -1
+            for filename in self.filenames:
+                try:
+                    time = os.path.getmtime(filename)
+                except OSError:
+                    err_logger(filename)
+                else:
+                    if time > max_time:
+                        max_time = time
+            return max_time
+
+    return LoggingMTimeComparator
+
+
 class MD5Comparator(object):
     """Compare files by md5 hash of their contents. This comparator will be
     slower for larger files, but is more resilient to modifications which only

--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -415,10 +415,27 @@ class InodeComparator(object):
         return last_inodes != self.inodes
 
 
+def build_compare_func(err_logger=None):
+    """Returns a compare_func that can be passed to MTimeComparator.
+
+    The returned compare_func first tries os.path.getmtime(filename),
+    then calls err_logger(filename) if that fails. If err_logger is None,
+    then it does nothing. err_logger is always called within the context of
+    an OSError raised by os.path.getmtime(filename). Information on this
+    error can be retrieved by calling sys.exc_info inside of err_logger."""
+    def compare_func(filename):
+        try:
+            return os.path.getmtime(filename)
+        except OSError:
+            if err_logger is not None:
+                err_logger(filename)
+        return -1
+    return compare_func
+
+
 class MTimeComparator(object):
-    """Compare files by modified time. If os.path.getmtime(filename) fails,
-    calls err_logger(filename) if it exists in the context of the raised
-    OSError, thus sys.exc_info() can be used to examine the exception.
+    """Compare files by modified time, or using compare_func,
+    if it is not None.
 
     .. note::
 
@@ -426,18 +443,11 @@ class MTimeComparator(object):
         so multiple changes within the same second can be ignored.
     """
 
-    def __init__(self, filenames, err_logger=None):
+    def __init__(self, filenames, compare_func=None):
         self.filenames = filenames
-        self.err_logger = err_logger
+        self.compare_func = (os.path.getmtime if compare_func is None
+                             else compare_func)
         self.last_max_mtime = self.get_most_recent_changed()
-
-    def compare_func(self, filename):
-        try:
-            return os.path.getmtime(filename)
-        except OSError:
-            if self.err_logger is not None:
-                self.err_logger(filename)
-        return -1
 
     def get_most_recent_changed(self):
         if not self.filenames:

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -446,10 +446,11 @@ class TestMTimeComparator(object):
         assert comparator.has_changed()
 
 
-class TestLoggingMTimeComparator(object):
+class TestMTimeComparatorWithCompareFunc(object):
 
     def __init__(self):
-        self._LoggingMTimeComparator = functools.partial(config.MTimeComparator, err_logger=self._err_logger)
+        self._LoggingMTimeComparator = functools.partial(
+            config.MTimeComparator, compare_func=config.build_compare_func(self._err_logger))
 
     @pytest.fixture(autouse=True)
     def _reset_err_logger(self):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -4,6 +4,7 @@ import platform
 import tempfile
 import time
 import sys
+import functools
 
 import pytest
 
@@ -448,7 +449,7 @@ class TestMTimeComparator(object):
 class TestLoggingMTimeComparator(object):
 
     def __init__(self):
-        self._LoggingMTimeComparator = config.create_LoggingMTimeComparator(self._err_logger)
+        self._LoggingMTimeComparator = functools.partial(config.MTimeComparator, err_logger=self._err_logger)
 
     @pytest.fixture(autouse=True)
     def _reset_err_logger(self):

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -456,15 +456,15 @@ class TestLoggingMTimeComparator(object):
     def _err_logger(self, filename):
         self._err_filename = filename
 
-    def test_get_most_recent_empty(self):
-        comparator = self._LoggingMTimeComparator([])
-        assert comparator.get_most_recent_changed() == -1
-        assert self._err_filename is None
-
     def test_logs_error(self):
         comparator = self._LoggingMTimeComparator(['./not.a.file'])
         assert comparator.get_most_recent_changed() == -1
         assert self._err_filename == "./not.a.file"
+
+    def test_get_most_recent_empty(self):
+        comparator = self._LoggingMTimeComparator([])
+        assert comparator.get_most_recent_changed() == -1
+        assert self._err_filename is None
 
     @mock.patch('staticconf.config.os.path.getmtime', autospec=True, side_effect=[0,0,1,2,3])
     def test_get_most_recent(self, mock_mtime):


### PR DESCRIPTION
I work for @Yelp. We use `staticconf` to load our configuration files. Sometimes, if something goes wrong, configuration files can disappear. If this happens, we would prefer that error get logged instead of propagating to prevent it from taking down the entire infrastructure. To accomplish this, I have added a function `create_LoggingMTimeComparator(err_logger)` which takes in some logging function and returns an `MTimeComparator` subclass that calls that logging function when a file can't be found instead of propagating an `OSError`.