### PR TITLE
Dont log unknown values

### DIFF
--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -88,8 +88,18 @@ class ConfigNamespace(object):
     def register_proxy(self, proxy):
         self.value_proxies[id(proxy)] = proxy
 
-    def apply_config_data(self, config_data, error_on_unknown, error_on_dupe):
-        self.validate_keys(config_data, error_on_unknown)
+    def apply_config_data(
+        self,
+        config_data,
+        error_on_unknown,
+        error_on_dupe,
+        log_keys_only=False,
+    ):
+        self.validate_keys(
+            config_data,
+            error_on_unknown,
+            log_keys_only=log_keys_only,
+        )
         self.has_duplicate_keys(config_data, error_on_dupe)
         self.update_values(config_data)
 
@@ -116,10 +126,18 @@ class ConfigNamespace(object):
     def get_known_keys(self):
         return set(vproxy.config_key for vproxy in self.get_value_proxies())
 
-    def validate_keys(self, config_data, error_on_unknown):
+    def validate_keys(
+        self,
+        config_data,
+        error_on_unknown,
+        log_keys_only=False,
+    ):
         unknown = remove_by_keys(config_data, self.get_known_keys())
         if not unknown:
             return
+
+        if log_keys_only:
+            unknown = [k for k, _ in unknown]
 
         msg = "Unexpected value in %s configuration: %s" % (self.name, unknown)
         if error_on_unknown:

--- a/staticconf/loader.py
+++ b/staticconf/loader.py
@@ -137,6 +137,7 @@ def load_config_data(loader_func, *args, **kwargs):
 def build_loader(loader_func):
     def loader(*args, **kwargs):
         err_on_unknown      = kwargs.pop('error_on_unknown', False)
+        log_keys_only       = kwargs.pop('log_keys_only', False)
         err_on_dupe         = kwargs.pop('error_on_duplicate', False)
         flatten             = kwargs.pop('flatten', True)
         name                = kwargs.pop('namespace', config.DEFAULT)
@@ -145,7 +146,12 @@ def build_loader(loader_func):
         if flatten:
             config_data = dict(flatten_dict(config_data))
         namespace   = config.get_namespace(name)
-        namespace.apply_config_data(config_data, err_on_unknown, err_on_dupe)
+        namespace.apply_config_data(
+            config_data,
+            err_on_unknown,
+            err_on_dupe,
+            log_keys_only=log_keys_only,
+        )
         return config_data
 
     return loader

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -10,6 +10,8 @@ import pytest
 
 from testing.testifycompat import (
     assert_equal,
+    assert_in,
+    assert_not_in,
     assert_raises,
     mock,
 )
@@ -149,6 +151,25 @@ class TestConfigurationNamespace(object):
         with mock.patch('staticconf.config.log') as mock_log:
             self.namespace.validate_keys(self.config_data, False)
             assert_equal(len(mock_log.info.mock_calls), 1)
+
+    def test_validate_keys_unknown_log_keys_only(self):
+        with mock.patch('staticconf.config.log') as mock_log:
+            self.namespace.validate_keys(
+                self.config_data,
+                False,
+                log_keys_only=True,
+            )
+            assert_equal(len(mock_log.info.mock_calls), 1)
+            log_msg = mock_log.info.call_args[0][0]
+            unknown = config.remove_by_keys(
+                self.config_data,
+                self.namespace.get_known_keys(),
+            )
+            for k, v in unknown:
+                # Have to cast to strings here, since log_msg is a string
+                key_string, val_string = str(k), str(v)
+                assert_in(key_string, log_msg)
+                assert_not_in(val_string, log_msg)
 
     def test_validate_keys_unknown_raise(self):
         assert_raises(errors.ConfigurationError,

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -10,8 +10,6 @@ import pytest
 
 from testing.testifycompat import (
     assert_equal,
-    assert_in,
-    assert_not_in,
     assert_raises,
     mock,
 )
@@ -168,8 +166,8 @@ class TestConfigurationNamespace(object):
             for k, v in unknown:
                 # Have to cast to strings here, since log_msg is a string
                 key_string, val_string = str(k), str(v)
-                assert_in(key_string, log_msg)
-                assert_not_in(val_string, log_msg)
+                assert key_string in log_msg
+                assert val_string not in log_msg
 
     def test_validate_keys_unknown_raise(self):
         assert_raises(errors.ConfigurationError,


### PR DESCRIPTION
If users of this package happened to forget to register a key that stores sensitive data, that sensitive data would be logged in `ConfigNamespace.validate_keys()`.

This change adds an optional argument to turn on this behavior.
It currently defaults to False, but it may be nice to change this to True, so that all users need to do to enable this feature is to bump their package version, but I am not sure what you think.