### PR TITLE
Makes the default for log_keys_only True

### DIFF
--- a/staticconf/loader.py
+++ b/staticconf/loader.py
@@ -137,7 +137,7 @@ def load_config_data(loader_func, *args, **kwargs):
 def build_loader(loader_func):
     def loader(*args, **kwargs):
         err_on_unknown      = kwargs.pop('error_on_unknown', False)
-        log_keys_only       = kwargs.pop('log_keys_only', False)
+        log_keys_only       = kwargs.pop('log_keys_only', True)
         err_on_dupe         = kwargs.pop('error_on_duplicate', False)
         flatten             = kwargs.pop('flatten', True)
         name                = kwargs.pop('namespace', config.DEFAULT)


### PR DESCRIPTION
This only affects loaders. The actual defaults in `staticconf.config` are unchanged.
