### PR TITLE
Use the safe yaml loader instead of the default eval loader.

### DIFF
--- a/staticconf/loader.py
+++ b/staticconf/loader.py
@@ -160,12 +160,12 @@ def build_loader(loader_func):
 def yaml_loader(filename):
     import yaml
     try:
-        from yaml import CLoader as Loader
+        from yaml import CSafeLoader as SafeLoader
     except ImportError:
-        from yaml import Loader
+        from yaml import SafeLoader
 
     with open(filename) as fh:
-        return yaml.load(fh, Loader=Loader) or {}
+        return yaml.load(fh, Loader=SafeLoader) or {}
 
 
 def json_loader(filename):


### PR DESCRIPTION
This would be a major change, but I think a good one.

[yaml--](https://github.com/asottile/wat/blob/master/python/yaml_lols.py)