### PR TITLE
Added comparators parameter to ConfigFacade

### DIFF
--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -582,7 +582,14 @@ class ConfigFacade(object):
         self.callback_chain = watcher.get_reloader()
 
     @classmethod
-    def load(cls, filename, namespace, loader_func, min_interval=0):
+    def load(
+            cls,
+            filename,
+            namespace,
+            loader_func,
+            min_interval=0,
+            comparators=None,
+    ):
         """Create a new :class:`ConfigurationWatcher` and load the initial
         configuration by calling `loader_func`.
 
@@ -597,13 +604,18 @@ class ConfigFacade(object):
         :param min_interval: minimum number of seconds to wait between calls to
                              :func:`os.path.getmtime` to check if a file has
                              been modified.
+        :param comparators: a list of classes which support the
+            :class:`IComparator` interface which are used to determine if a config
+            file has been modified. See ConfigurationWatcher::__init__.
         :returns: a :class:`ConfigFacade`
         """
         watcher = ConfigurationWatcher(
             build_loader_callable(loader_func, filename, namespace=namespace),
             filename,
             min_interval=min_interval,
-            reloader=ReloadCallbackChain(namespace=namespace))
+            reloader=ReloadCallbackChain(namespace=namespace),
+            comparators=comparators,
+        )
         watcher.load_config()
         return cls(watcher)
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -598,6 +598,18 @@ class TestConfigFacade(object):
         reloader = facade.callback_chain
         assert_equal(reloader, facade.watcher.get_reloader())
 
+    def test_load_passes_comparators_to_configuration_watcher(self):
+        filename, namespace = "filename", "namespace"
+        loader = mock.Mock()
+        comparator = mock.Mock(name='MockComparator')
+
+        with mock.patch(
+            'staticconf.config.ConfigurationWatcher',
+            autospec=True
+        ) as mock_watcher_class:
+            config.ConfigFacade.load(filename, namespace, loader, comparators=[comparator])
+            mock_watcher_class.assert_called_with(mock.ANY, filename, min_interval=mock.ANY, reloader=mock.ANY, comparators=[comparator])
+
     def test_add_callback(self):
         name, func = 'name', mock.Mock()
         self.facade.add_callback(name, func)


### PR DESCRIPTION
I want to be able to use a different comparator (MD5Comparator) with a ConfigFacade. So I added the parameter to the ConfigFacade::load method (with a default value, so it's backwards-compatible)