### PR TITLE
Include the LICENSE file using the license_file metadata instead of data_files

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,9 @@ upload-dir = docs/build/html
 [wheel]
 universal = True
 
+[metadata]
+license_file = LICENSE
+
 [flake8]
 max-line-length = 85
 max-complexity = 8

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,4 @@ setup(
     packages=['staticconf'],
     install_requires=['six'],
     license='APACHE20',
-    data_files=[("", ["LICENSE"])],
 )


### PR DESCRIPTION
In #98 the LICENSE file began being included via the `data_files` setuptools metadata. This currently places LICENSE in sys.prefix, which is not a good location for this file. It looks like setuptools already includes LICENSE in the sdist without `data_files`.

The change to setup.cfg makes it so that LICENSE is also included in the built wheel.