### PR TITLE
Add typing annotations

### DIFF
--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -1,0 +1,23 @@
+name: Type validation
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7']
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+
+    - name: Install dependencies
+      run: python -m pip install tox
+
+    - name: Run ${{ matrix.python-version }} mypy
+      run: tox -e mypy

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,3 @@
+# See https://mypy.readthedocs.io/en/stable/config_file.html
+[mypy]
+python_version = 3.7

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,3 +1,4 @@
 # See https://mypy.readthedocs.io/en/stable/config_file.html
 [mypy]
 python_version = 3.7
+disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,12 @@
 [mypy]
 python_version = 3.7
 disallow_untyped_defs = True
+disallow_incomplete_defs = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_subclassing_any = True
+disallow_any_generics = True
+warn_unused_ignores = True
+warn_unreachable = True
+show_error_context = True
+show_column_numbers = True

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,8 @@ setup(
         'yaml': ['pyyaml'],
     },
     packages=['staticconf'],
+    package_data={
+        "staticconf": ["py.typed"],
+    },
     license='APACHE20',
 )

--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -15,10 +15,30 @@ from collections import namedtuple
 import hashlib
 import logging
 import os
+import sys
 import time
 import weakref
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Tuple
+from typing import Type
+from typing import Union
 
 from staticconf import errors
+from staticconf.proxy import ValueProxy
+from staticconf.validation import Validator
+
+
+if sys.version_info >= (3, 10):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
+
 
 log = logging.getLogger(__name__)
 
@@ -27,10 +47,11 @@ log = logging.getLogger(__name__)
 DEFAULT = 'DEFAULT'
 
 
-def remove_by_keys(dictionary, keys):
-    keys = set(keys)
-
-    def filter_by_keys(item):
+def remove_by_keys(
+    dictionary: Dict[str, Any],
+    keys: Set[str]
+) -> List[Tuple[str, Any]]:
+    def filter_by_keys(item: Tuple[str, Any]) -> bool:
         k, _ = item
         return k not in keys
     return list(filter(filter_by_keys, dictionary.items()))
@@ -41,19 +62,19 @@ class ConfigMap:
     It will allow you to retain your mapping structure (and prevent it
     from being flattened).
     """
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.data = dict(*args, **kwargs)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str) -> Any:
         return self.data[item]
 
-    def get(self, item, default=None):
+    def get(self, item: str, default: Any = None) -> Any:
         return self.data.get(item, default)
 
-    def __contains__(self, item):
+    def __contains__(self, item: str) -> bool:
         return item in self.data
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.data)
 
 
@@ -72,27 +93,28 @@ class ConfigNamespace:
     or :mod:`staticconf.schema`.
     """
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         self.name = name
-        self.configuration_values = {}
-        self.value_proxies = weakref.WeakValueDictionary()
+        self.configuration_values: Dict[str, Any] = {}
+        self.value_proxies: weakref.WeakValueDictionary[int, ValueProxy] = \
+            weakref.WeakValueDictionary()
 
-    def get_name(self):
+    def get_name(self) -> str:
         return self.name
 
-    def get_value_proxies(self):
+    def get_value_proxies(self) -> List[ValueProxy]:
         return list(self.value_proxies.values())
 
-    def register_proxy(self, proxy):
+    def register_proxy(self, proxy: ValueProxy) -> None:
         self.value_proxies[id(proxy)] = proxy
 
     def apply_config_data(
         self,
-        config_data,
-        error_on_unknown,
-        error_on_dupe,
-        log_keys_only=False,
-    ):
+        config_data: Dict[str, Any],
+        error_on_unknown: bool,
+        error_on_dupe: bool,
+        log_keys_only: bool = False,
+    ) -> None:
         self.validate_keys(
             config_data,
             error_on_unknown,
@@ -101,19 +123,19 @@ class ConfigNamespace:
         self.has_duplicate_keys(config_data, error_on_dupe)
         self.update_values(config_data)
 
-    def update_values(self, *args, **kwargs):
+    def update_values(self, *args: Any, **kwargs: Any) -> None:
         self.configuration_values.update(*args, **kwargs)
 
-    def get_config_values(self):
+    def get_config_values(self) -> Dict[str, Any]:
         """Return all configuration stored in this object as a dict.
         """
         return self.configuration_values
 
-    def get_config_dict(self):
+    def get_config_dict(self) -> Dict[str, Any]:
         """Reconstruct the nested structure of this object's configuration
         and return it as a dict.
         """
-        config_dict = {}
+        config_dict: Dict[str, Any] = {}
         for dotted_key, value in self.get_config_values().items():
             subkeys = dotted_key.split('.')
             d = config_dict
@@ -121,52 +143,57 @@ class ConfigNamespace:
                 d = d.setdefault(key, value if key == subkeys[-1] else {})
         return config_dict
 
-    def get_known_keys(self):
+    def get_known_keys(self) -> Set[str]:
         return {vproxy.config_key for vproxy in self.get_value_proxies()}
 
     def validate_keys(
         self,
-        config_data,
-        error_on_unknown,
-        log_keys_only=False,
-    ):
+        config_data: Dict[str, Any],
+        error_on_unknown: bool,
+        log_keys_only: bool = False,
+    ) -> None:
         unknown = remove_by_keys(config_data, self.get_known_keys())
         if not unknown:
             return
 
         if log_keys_only:
-            unknown = [k for k, _ in unknown]
+            unknown_keys = [k for k, _ in unknown]
+            msg = f"Unexpected value in {self.name} configuration: {unknown_keys}"
+        else:
+            msg = f"Unexpected value in {self.name} configuration: {unknown}"
 
-        msg = f"Unexpected value in {self.name} configuration: {unknown}"
         if error_on_unknown:
             raise errors.ConfigurationError(msg)
         log.info(msg)
 
-    def has_duplicate_keys(self, config_data, error_on_duplicate):
+    def has_duplicate_keys(
+        self,
+        config_data: Dict[str, Any], error_on_duplicate: bool
+    ) -> bool:
         args = config_data, self.configuration_values, error_on_duplicate
         return has_duplicate_keys(*args)
 
-    def get(self, item, default=None):
+    def get(self, item: str, default: Any = None) -> Any:
         return self.configuration_values.get(item, default)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: str) -> Any:
         return self.configuration_values[item]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: str, value: Any) -> None:
         self.configuration_values[key] = value
 
-    def __contains__(self, item):
+    def __contains__(self, item: str) -> bool:
         return item in self.configuration_values
 
-    def clear(self):
+    def clear(self) -> None:
         """Remove all values from the namespace."""
         self.configuration_values.clear()
 
-    def _reset(self):
+    def _reset(self) -> None:
         self.clear()
         self.value_proxies.clear()
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"{type(self).__name__}({self.name})"
 
 
@@ -176,14 +203,17 @@ configuration_namespaces = {DEFAULT: ConfigNamespace(DEFAULT)}
 KeyDescription = namedtuple('KeyDescription', 'name validator default help')
 
 
-def get_namespaces_from_names(name, all_names):
+def get_namespaces_from_names(
+    name: str,
+    all_names: bool
+) -> Iterator[ConfigNamespace]:
     """Return a generator which yields namespace objects."""
     names = configuration_namespaces.keys() if all_names else [name]
     for name in names:
         yield get_namespace(name)
 
 
-def get_namespace(name):
+def get_namespace(name: str) -> ConfigNamespace:
     """Return a :class:`ConfigNamespace` by name, creating the
     namespace if it does not exist.
     """
@@ -192,7 +222,7 @@ def get_namespace(name):
     return configuration_namespaces[name]
 
 
-def reload(name=DEFAULT, all_names=False):
+def reload(name: str = DEFAULT, all_names: bool = False) -> None:
     """Reload one or all :class:`ConfigNamespace`. Reload clears the cache of
     :mod:`staticconf.schema` and :mod:`staticconf.getters`, allowing them to
     pickup the latest values in the namespace.
@@ -207,7 +237,7 @@ def reload(name=DEFAULT, all_names=False):
             value_proxy.reset()
 
 
-def validate(name=DEFAULT, all_names=False):
+def validate(name: str = DEFAULT, all_names: bool = False) -> None:
     """Validate all registered keys after loading configuration.
 
     Missing values or values which do not pass validation raise
@@ -226,29 +256,36 @@ def validate(name=DEFAULT, all_names=False):
 class ConfigHelp:
     """Register and display help messages about config keys."""
 
-    def __init__(self):
-        self.descriptions = {}
+    def __init__(self) -> None:
+        self.descriptions: Dict[str, List[KeyDescription]] = {}
 
-    def add(self, name, validator, default, namespace, help):
+    def add(
+        self,
+        name: str,
+        validator: Validator,
+        default: Any,
+        namespace: str,
+        help: Optional[str]
+    ) -> None:
         desc = KeyDescription(name, validator, default, help)
         self.descriptions.setdefault(namespace, []).append(desc)
 
-    def view_help(self):
+    def view_help(self) -> str:
         """Return a help message describing all the statically configured keys.
         """
-        def format_desc(desc):
+        def format_desc(desc: KeyDescription) -> str:
             return "{} (Type: {}, Default: {})\n{}".format(
                     desc.name,
                     desc.validator.__name__.replace('validate_', ''),
                     desc.default,
                     desc.help or '')
 
-        def format_namespace(key, desc_list):
+        def format_namespace(key: str, desc_list: List[KeyDescription]) -> str:
             return "\nNamespace: {}\n{}".format(
                     key,
                     '\n'.join(sorted(format_desc(desc) for desc in desc_list)))
 
-        def namespace_cmp(item):
+        def namespace_cmp(item: Tuple[str, Any]) -> str:
             name, _ = item
             return chr(0) if name == DEFAULT else name
 
@@ -256,7 +293,7 @@ class ConfigHelp:
                          sorted(self.descriptions.items(),
                                 key=namespace_cmp))
 
-    def clear(self):
+    def clear(self) -> None:
         self.descriptions.clear()
 
 
@@ -264,19 +301,23 @@ config_help = ConfigHelp()
 view_help = config_help.view_help
 
 
-def _reset():
+def _reset() -> None:
     """Used for internal testing."""
     for namespace in configuration_namespaces.values():
         namespace._reset()
     config_help.clear()
 
 
-def has_duplicate_keys(config_data, base_conf, raise_error):
+def has_duplicate_keys(
+    config_data: Dict[str, Any],
+    base_conf: Dict[str, Any],
+    raise_error: bool
+) -> bool:
     """Compare two dictionaries for duplicate keys. if raise_error is True
     then raise on exception, otherwise log return True."""
     duplicate_keys = set(base_conf) & set(config_data)
     if not duplicate_keys:
-        return
+        return False
     msg = "Duplicate keys in config: %s" % duplicate_keys
     if raise_error:
         raise errors.ConfigurationError(msg)
@@ -338,11 +379,12 @@ class ConfigurationWatcher:
 
     def __init__(
             self,
-            config_loader,
-            filenames,
-            min_interval=0,
-            reloader=None,
-            comparators=None):
+            config_loader: Callable[[], Dict[str, Any]],
+            filenames: Union[str, List[str]],
+            min_interval: int = 0,
+            reloader: Optional["Reloader"] = None,
+            comparators: Optional[List[Type["IComparator"]]] = None,
+    ) -> None:
         self.config_loader  = config_loader
         self.filenames      = self.get_filename_list(filenames)
         self.min_interval   = min_interval
@@ -351,7 +393,7 @@ class ConfigurationWatcher:
         comparators         = comparators or [MTimeComparator]
         self.comparators    = [comp(self.filenames) for comp in comparators]
 
-    def get_filename_list(self, filenames):
+    def get_filename_list(self, filenames: Union[str, List[str]]) -> List[str]:
         if isinstance(filenames, str):
             filenames = [filenames]
         filenames = sorted(os.path.abspath(name) for name in filenames)
@@ -361,10 +403,10 @@ class ConfigurationWatcher:
         return filenames
 
     @property
-    def should_check(self):
+    def should_check(self) -> bool:
         return self.last_check + self.min_interval <= time.time()
 
-    def reload_if_changed(self, force=False):
+    def reload_if_changed(self, force: bool = False) -> Optional[Dict[str, Any]]:
         """If the file(s) being watched by this object have changed,
         their configuration will be loaded again using `config_loader`.
         Otherwise this is a noop.
@@ -375,20 +417,21 @@ class ConfigurationWatcher:
         """
         if (force or self.should_check) and self.file_modified():
             return self.reload()
+        return None
 
-    def file_modified(self):
+    def file_modified(self) -> bool:
         self.last_check = time.time()
         return any(comp.has_changed() for comp in self.comparators)
 
-    def reload(self):
+    def reload(self) -> Dict[str, Any]:
         config_dict = self.config_loader()
         self.reloader()
         return config_dict
 
-    def get_reloader(self):
+    def get_reloader(self) -> "Reloader":
         return self.reloader
 
-    def load_config(self):
+    def load_config(self) -> Dict[str, Any]:
         return self.config_loader()
 
 
@@ -402,36 +445,38 @@ class IComparator:
     :param filenames: A list of absolute paths to configuration files.
     """
 
-    def __init__(self, filenames):
+    def __init__(self, filenames: List[str]) -> None:
         pass
 
-    def has_changed(self):
+    def has_changed(self) -> bool:
         """Returns True if any of the files have been modified since the last
         call to :func:`has_changed`. Returns False otherwise.
         """
         pass
 
 
-class InodeComparator:
+class InodeComparator(IComparator):
     """Compare files by inode and device number. This is a good comparator to
     use when your files can change multiple times per second.
     """
 
-    def __init__(self, filenames):
+    def __init__(self, filenames: List[str]) -> None:
         self.filenames = filenames
         self.inodes = self.get_inodes()
 
-    def get_inodes(self):
-        def get_inode(stbuf):
+    def get_inodes(self) -> List[Tuple[int, int]]:
+        def get_inode(stbuf: os.stat_result) -> Tuple[int, int]:
             return stbuf.st_dev, stbuf.st_ino
         return [get_inode(os.stat(filename)) for filename in self.filenames]
 
-    def has_changed(self):
+    def has_changed(self) -> bool:
         last_inodes, self.inodes = self.inodes, self.get_inodes()
         return last_inodes != self.inodes
 
 
-def build_compare_func(err_logger=None):
+def build_compare_func(
+    err_logger: Optional[Callable[[str], None]] = None
+) -> Callable[[str], float]:
     """Returns a compare_func that can be passed to MTimeComparator.
 
     The returned compare_func first tries os.path.getmtime(filename),
@@ -439,7 +484,7 @@ def build_compare_func(err_logger=None):
     then it does nothing. err_logger is always called within the context of
     an OSError raised by os.path.getmtime(filename). Information on this
     error can be retrieved by calling sys.exc_info inside of err_logger."""
-    def compare_func(filename):
+    def compare_func(filename: str) -> float:
         try:
             return os.path.getmtime(filename)
         except OSError:
@@ -449,7 +494,7 @@ def build_compare_func(err_logger=None):
     return compare_func
 
 
-class MTimeComparator:
+class MTimeComparator(IComparator):
     """Compare files by modified time, or using compare_func,
     if it is not None.
 
@@ -459,14 +504,18 @@ class MTimeComparator:
         so multiple changes within the same second can be ignored.
     """
 
-    def __init__(self, filenames, compare_func=None):
+    def __init__(
+        self,
+        filenames: List[str],
+        compare_func: Optional[Callable[[str], bool]] = None
+    ) -> None:
         self.compare_func = (os.path.getmtime if compare_func is None
                              else compare_func)
         self.filenames_mtimes = {
             filename: self.compare_func(filename) for filename in filenames
         }
 
-    def has_changed(self):
+    def has_changed(self) -> bool:
         for filename, compare_val in self.filenames_mtimes.items():
             current_compare_val = self.compare_func(filename)
             if compare_val != current_compare_val:
@@ -476,27 +525,46 @@ class MTimeComparator:
         return False
 
 
-class MD5Comparator:
+class MD5Comparator(IComparator):
     """Compare files by md5 hash of their contents. This comparator will be
     slower for larger files, but is more resilient to modifications which only
     change mtime, but not the files contents.
     """
 
-    def __init__(self, filenames):
+    def __init__(self, filenames: str) -> None:
         self.filenames = filenames
         self.hashes = self.get_hashes()
 
-    def get_hashes(self):
-        def build_hash(filename):
+    def get_hashes(self) -> List[bytes]:
+        def build_hash(filename: str) -> bytes:
             hasher = hashlib.md5()
             with open(filename, 'rb') as fh:
                 hasher.update(fh.read())
             return hasher.digest()
         return [build_hash(filename) for filename in self.filenames]
 
-    def has_changed(self):
+    def has_changed(self) -> bool:
         last_hashes, self.hashes = self.hashes, self.get_hashes()
         return last_hashes != self.hashes
+
+
+class Reloader(Protocol):
+    def __init__(
+        self,
+        namespace: str = DEFAULT,
+        all_names: bool = False,
+        callbacks: List[Tuple[str, Callable[[], None]]] = None,
+    ):
+        ...
+
+    def add(self, identifier: str, callback: Callable[[], None]) -> None:
+        ...
+
+    def remove(self, identifier: str) -> None:
+        ...
+
+    def __call__(self) -> None:
+        ...
 
 
 class ReloadCallbackChain:
@@ -526,25 +594,39 @@ class ReloadCallbackChain:
     :param callbacks: initial list of tuples to add to the callback chain
     """
 
-    def __init__(self, namespace=DEFAULT, all_names=False, callbacks=None):
+    def __init__(
+        self,
+        namespace: str = DEFAULT,
+        all_names: bool = False,
+        callbacks: List[Tuple[str, Callable[[], None]]] = None,
+    ):
         self.namespace = namespace
         self.all_names = all_names
         self.callbacks = dict(callbacks or ())
 
-    def add(self, identifier, callback):
+    def add(self, identifier: str, callback: Callable[[], None]) -> None:
         self.callbacks[identifier] = callback
 
-    def remove(self, identifier):
+    def remove(self, identifier: str) -> None:
         del self.callbacks[identifier]
 
-    def __call__(self):
+    def __call__(self) -> None:
         reload(name=self.namespace, all_names=self.all_names)
         for callback in self.callbacks.values():
             callback()
 
 
-def build_loader_callable(load_func, filename, namespace):
-    def load_configuration():
+class LoadFunc(Protocol):
+    def __call__(self, filename: str, namespace: str) -> Dict[str, Any]:
+        ...
+
+
+def build_loader_callable(
+    load_func: LoadFunc,
+    filename: str,
+    namespace: str
+) -> Callable[[], Dict[str, Any]]:
+    def load_configuration() -> Dict[str, Any]:
         get_namespace(namespace).clear()
         return load_func(filename, namespace=namespace)
     return load_configuration
@@ -575,19 +657,19 @@ class ConfigFacade:
         watcher.reload_if_changed()
     """
 
-    def __init__(self, watcher):
+    def __init__(self, watcher: ConfigurationWatcher) -> None:
         self.watcher = watcher
         self.callback_chain = watcher.get_reloader()
 
     @classmethod
     def load(
             cls,
-            filename,
-            namespace,
-            loader_func,
-            min_interval=0,
-            comparators=None,
-    ):
+            filename: str,
+            namespace: str,
+            loader_func: LoadFunc,
+            min_interval: int = 0,
+            comparators: Optional[List[Type[IComparator]]] = None,
+    ) -> "ConfigFacade":
         """Create a new :class:`ConfigurationWatcher` and load the initial
         configuration by calling `loader_func`.
 
@@ -617,9 +699,25 @@ class ConfigFacade:
         watcher.load_config()
         return cls(watcher)
 
-    def add_callback(self, identifier, callback):
+    def add_callback(self, identifier: str, callback: Callable[[], None]) -> None:
         self.callback_chain.add(identifier, callback)
 
-    def reload_if_changed(self, force=False):
+    def reload_if_changed(self, force: bool = False) -> None:
         """See :func:`ConfigurationWatcher.reload_if_changed` """
         self.watcher.reload_if_changed(force=force)
+
+
+ConfigGetValue = Union[
+    Callable[[str, Any, Optional[str]], Any],
+    Callable[[str, Any, Optional[str], Optional[str]], Any]
+]
+
+
+class NameFactory(Protocol):
+    @staticmethod
+    def get_name(name: str) -> str:
+        ...
+
+    @staticmethod
+    def get_list_of_name(validator_name: str) -> str:
+        ...

--- a/staticconf/proxy.py
+++ b/staticconf/proxy.py
@@ -8,7 +8,7 @@ import operator
 from staticconf import errors
 
 
-class UndefToken:
+class UndefTokenType:
     """A token to represent an undefined value, so that None can be used
     as a default value.
     """
@@ -16,7 +16,7 @@ class UndefToken:
         return "<Undefined>"
 
 
-UndefToken = UndefToken()
+UndefToken = UndefTokenType()
 
 
 _special_names = [

--- a/staticconf/proxy.py
+++ b/staticconf/proxy.py
@@ -4,15 +4,26 @@ values can be read statically at import time.
 """
 import functools
 import operator
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Type
+from typing import TypeVar
+from typing import TYPE_CHECKING
 
 from staticconf import errors
+from staticconf.validation import Validator
+
+
+if TYPE_CHECKING:
+    from staticconf.config import ConfigNamespace
 
 
 class UndefTokenType:
     """A token to represent an undefined value, so that None can be used
     as a default value.
     """
-    def __repr__(self):
+    def __repr__(self) -> str:
         return "<Undefined>"
 
 
@@ -39,24 +50,24 @@ _special_names = [
 ]
 
 
-def identity(x):
+def identity(x: Any) -> Any:
     return x
 
 
 unary_funcs = {
-    '__unicode__':  str,
-    '__str__':      str,
+    '__unicode__':  cast(Callable[[Any], Any], str),
+    '__str__':      cast(Callable[[Any], Any], str),
     '__fspath__':   identity,  # python3.6+ os.PathLike interface
-    '__repr__':     repr,
-    '__nonzero__':  bool,  # Python2 bool
-    '__bool__':     bool,  # Python3 bool
-    '__hash__':     hash,
+    '__repr__':     cast(Callable[[Any], Any], repr),
+    '__nonzero__':  cast(Callable[[Any], Any], bool),  # Python2 bool
+    '__bool__':     cast(Callable[[Any], Any], bool),  # Python3 bool
+    '__hash__':     cast(Callable[[Any], Any], hash),
 }
 
 
-def build_class_def(cls):
-    def build_method(name):
-        def method(self, *args, **kwargs):
+def build_class_def(cls: Type["ValueProxy"]) -> type:
+    def build_method(name: str) -> Callable[["ValueProxy", Any, Any], Any]:
+        def method(self: "ValueProxy", *args: Any, **kwargs: Any) -> Any:
             if name in unary_funcs:
                 return unary_funcs[name](self.value)
 
@@ -70,11 +81,14 @@ def build_class_def(cls):
     return type(cls.__name__, (cls,), namespace)
 
 
-def cache_as_field(cache_name):
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def cache_as_field(cache_name: str) -> Callable[[F], F]:
     """Cache a functions return value as the field 'cache_name'."""
-    def cache_wrapper(func):
+    def cache_wrapper(func: F) -> F:
         @functools.wraps(func)
-        def inner_wrapper(self, *args, **kwargs):
+        def inner_wrapper(self: object, *args: Any, **kwargs: Any) -> Any:
             value = getattr(self, cache_name, UndefToken)
             if value != UndefToken:
                 return value
@@ -82,11 +96,11 @@ def cache_as_field(cache_name):
             ret = func(self, *args, **kwargs)
             setattr(self, cache_name, ret)
             return ret
-        return inner_wrapper
+        return cast(F, inner_wrapper)
     return cache_wrapper
 
 
-def extract_value(proxy):
+def extract_value(proxy: "ValueProxy") -> Any:
     """Given a value proxy type, Retrieve a value from a namespace, raising
     exception if no value is found, or the value does not validate.
     """
@@ -115,17 +129,23 @@ class ValueProxy:
 
     @classmethod
     @cache_as_field('_class_def')
-    def get_class_def(cls):
+    def get_class_def(cls) -> type:
         return build_class_def(cls)
 
-    def __new__(cls, *args, **kwargs):
+    def __new__(cls, *args: Any, **kwargs: Any) -> "ValueProxy":
         """Create instances of this class with proxied special names."""
-        klass = cls.get_class_def()
-        instance = object.__new__(klass)
+        klass = cast(Type["ValueProxy"], cls.get_class_def())
+        instance = cast("ValueProxy", object.__new__(klass))
         klass.__init__(instance, *args, **kwargs)
         return instance
 
-    def __init__(self, validator, namespace, key, default=UndefToken):
+    def __init__(
+        self,
+        validator: Validator,
+        namespace: "ConfigNamespace",
+        key: str,
+        default: Any = UndefToken,
+    ) -> None:
         self.validator      = validator
         self.config_key     = key
         self.default        = default
@@ -133,14 +153,14 @@ class ValueProxy:
         self._value         = UndefToken
 
     @cache_as_field('_value')
-    def get_value(self):
+    def get_value(self) -> Any:
         return extract_value(self)
 
     value = property(get_value)
 
-    def __getattr__(self, item):
+    def __getattr__(self, item: str) -> Any:
         return getattr(self.value, item)
 
-    def reset(self):
+    def reset(self) -> None:
         """Clear the cached value so that configuration can be reloaded."""
         self._value = UndefToken

--- a/staticconf/testing.py
+++ b/staticconf/testing.py
@@ -2,6 +2,9 @@
 Facilitate testing of code which uses staticconf.
 """
 import copy
+from typing import Any
+from typing import Dict
+from typing import Optional
 
 from staticconf import config, loader
 
@@ -31,32 +34,32 @@ class MockConfiguration:
                 as configuration data
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         name                = kwargs.pop('namespace', config.DEFAULT)
         flatten             = kwargs.pop('flatten', True)
         config_data         = dict(*args, **kwargs)
         self.namespace      = config.get_namespace(name)
         self.config_data    = (dict(loader.flatten_dict(config_data)) if flatten
                               else config_data)
-        self.old_values     = None
+        self.old_values: Optional[Dict[str, Any]] = None
 
-    def setup(self):
+    def setup(self) -> None:
         self.old_values = dict(self.namespace.get_config_values())
         self.reset_namespace(self.config_data)
         config.reload(name=self.namespace.name)
 
-    def teardown(self):
+    def teardown(self) -> None:
         self.reset_namespace(self.old_values)
         config.reload(name=self.namespace.name)
 
-    def reset_namespace(self, new_values):
+    def reset_namespace(self, new_values: Optional[Dict[str, Any]]) -> None:
         self.namespace.configuration_values.clear()
         self.namespace.update_values(new_values)
 
-    def __enter__(self):
+    def __enter__(self) -> None:
         return self.setup()
 
-    def __exit__(self, *args):
+    def __exit__(self, *args: Any) -> None:
         self.teardown()
 
 
@@ -84,7 +87,7 @@ class PatchConfiguration(MockConfiguration):
     The arguments are identical to MockConfiguration.
     """
 
-    def setup(self):
+    def setup(self) -> None:
         self.old_values = copy.deepcopy(dict(self.namespace.get_config_values()))
         new_configuration = copy.deepcopy(self.old_values)
         new_configuration.update(self.config_data)

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     pytest
     mock <= 1.0.1
     flake8
+    typing-extensions
 commands =
     py.test {posargs:tests}
     flake8 staticconf tests testing
@@ -27,3 +28,14 @@ deps =
     coverage
 commands =
     coverage run --source=staticconf {envbindir}/py.test tests
+
+
+[testenv:mypy]
+basepython = python3.7
+deps =
+    mypy
+    typing-extensions
+    types-PyYAML
+    types-simplejson
+commands =
+    mypy staticconf


### PR DESCRIPTION
Following mypy output, I typed each file until no errors were left.

Additionally added GHA for `tox -e mypy` to prevent regressions in PRs.

### Notes

There's a circular type dependency between `config.py` (`ConfigNamespace`) and `proxy.py` (`ValueProxy`) which is guarded by `TYPE_CHECKING`.

While I don't explicitly test for py3.10, `Protocol` was moved from `typing-extensions` to `typing` so there's a version guard for the `Protocol` import.

In `statticonfig/loader`, there are many `Comparator`s using the `IComparator` interface. Normally, I would turn `IComparator` into a `Protocol`, but one of the classes adds a default keyword arg to `__init__` which makes it different. To facilitate typing, I opted to make the inheritance explicit instead.

Closes #108 