### PR TITLE
Readers and Getters are `ValueProxy` objects

### DIFF
--- a/staticconf/config.py
+++ b/staticconf/config.py
@@ -31,6 +31,7 @@ from typing import Union
 
 from staticconf import errors
 from staticconf.proxy import ValueProxy
+from staticconf.proxy import UndefToken
 from staticconf.validation import Validator
 
 
@@ -707,10 +708,15 @@ class ConfigFacade:
         self.watcher.reload_if_changed(force=force)
 
 
-ConfigGetValue = Union[
-    Callable[[str, Any, Optional[str]], Any],
-    Callable[[str, Any, Optional[str], Optional[str]], Any]
-]
+class ConfigGetValue(Protocol):
+    def __call__(
+        self,
+        key_name: str,
+        default: Any = UndefToken,
+        help_or_namespace: Optional[str] = None,
+        namespace_or_unused: Optional[str] = None
+    ) -> ValueProxy:
+        ...
 
 
 class NameFactory(Protocol):

--- a/staticconf/getters.py
+++ b/staticconf/getters.py
@@ -123,23 +123,25 @@ def build_getter(
     """Create a getter function for retrieving values from the config cache.
     Getters will default to the DEFAULT namespace.
     """
-    def proxy_register(
-        key_name: str,
-        default: Any = UndefToken,
-        help: Optional[str] = None,
-        namespace: Optional[str] = None
-    ) -> ValueProxy:
-        name        = namespace or getter_namespace or config.DEFAULT
-        config_namespace   = config.get_namespace(name)
-        return proxy_factory.build(
-            validator,
-            config_namespace,
-            key_name,
-            default,
-            help
-        )
+    class ProxyRegister(ConfigGetValue):
+        def __call__(
+            self,
+            key_name: str,
+            default: Any = UndefToken,
+            help: Optional[str] = None,
+            namespace: Optional[str] = None,
+        ) -> ValueProxy:
+            name        = namespace or getter_namespace or config.DEFAULT
+            config_namespace   = config.get_namespace(name)
+            return proxy_factory.build(
+                validator,
+                config_namespace,
+                key_name,
+                default,
+                help
+            )
 
-    return proxy_register
+    return ProxyRegister()
 
 
 class GetterNameFactory:

--- a/staticconf/getters.py
+++ b/staticconf/getters.py
@@ -131,8 +131,8 @@ def build_getter(
             help: Optional[str] = None,
             namespace: Optional[str] = None,
         ) -> ValueProxy:
-            name        = namespace or getter_namespace or config.DEFAULT
-            config_namespace   = config.get_namespace(name)
+            name                = namespace or getter_namespace or config.DEFAULT
+            config_namespace    = config.get_namespace(name)
             return proxy_factory.build(
                 validator,
                 config_namespace,

--- a/staticconf/readers.py
+++ b/staticconf/readers.py
@@ -99,6 +99,7 @@ from typing import Type
 from staticconf import validation, config, errors
 from staticconf.config import ConfigNamespace
 from staticconf.config import ConfigGetValue
+from staticconf.proxy import ValueProxy
 from staticconf.proxy import UndefToken
 from staticconf.validation import Validator
 import sys
@@ -138,14 +139,17 @@ def build_reader(
     :param reader_namespace: the default namespace to use. Defaults to
                              `DEFAULT`.
     """
-    def reader(
-        config_key: str,
-        default: Any = UndefToken,
-        namespace: Optional[str] = None
-    ) -> Any:
-        config_namespace = config.get_namespace(namespace or reader_namespace)
-        return validator(_read_config(config_key, config_namespace, default))
-    return reader
+    class Reader(ConfigGetValue):
+        def __call__(
+            self,
+            config_key: str,
+            default: Any = UndefToken,
+            namespace: Optional[str] = None,
+            unsued: Optional[str] = None,
+        ) -> ValueProxy:
+            config_namespace = config.get_namespace(namespace or reader_namespace)
+            return validator(_read_config(config_key, config_namespace, default))
+    return Reader()
 
 
 class NameFactory(Protocol):


### PR DESCRIPTION
## Problem

When creating a new getter,
```
conf = staticconf.getters.NamespaceGetters(namepace)
entry = conf.get("some_entry", help="Some entry in the configuration")

filename = entry.value
```

`entry` is currently of type `Any`. This should in fact be a `ValueProxy` type. This type comes from the `ConfigGetValue` type.


## Solution

* Narrow type definition of Readers and Getters
    * `ConfigGetValue` redefined as a `Protocol`
    * Consolidated the parameter list to a single combination to
         simplify the implementation of the Protocol. Fortunately, the
         signatures are type compatible, although the meaning of the
         parameters changes between readers and getters.
    * `ConfigGetValue` returns a `ProxyValue` instead of `Any`

## Action Plan

- [ ] Merge before #116