### PR TITLE
`Schema.namespace` is an optional `str`

### DIFF
--- a/staticconf/schema.py
+++ b/staticconf/schema.py
@@ -207,7 +207,7 @@ class SchemaMeta(type):
 class Schema(metaclass=SchemaMeta):
     """Base class for configuration schemas, uses :class:`SchemaMeta`."""
 
-    namespace = None
+    namespace: Optional[str] = None
 
 
 def build_value_type(validator: Validator) -> Callable[[Any, Any], Any]:


### PR DESCRIPTION
A `Schema` class will inherit the base `Schema` and define `namespace`

```
class MySchema(Schema):
    namespace = "my_namespace"
```

## Action Plan:
- [ ] Merge before #116 