### PR TITLE
Add `typing-extensions` to `install_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup(
         "Development Status :: 5 - Production/Stable",
     ],
     python_requires=">=3.6",
+    install_requires=[
+        'typing-extensions',
+    ],
     extras_require={
         'yaml': ['pyyaml'],
     },


### PR DESCRIPTION
@jvperrin noticed in https://github.com/dnephin/PyStaticConfiguration/pull/116#pullrequestreview-1136783027_ that I forgot a requirement in #112 

## Action Plan
- [ ] Merge before #113 