### PR TITLE
Cleanup pytest warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    acceptance

--- a/staticconf/loader.py
+++ b/staticconf/loader.py
@@ -224,7 +224,7 @@ def object_loader(obj: Any) -> ConfigDict:
 
 
 def ini_file_loader(filename: str) -> ConfigDict:
-    parser = configparser.SafeConfigParser()
+    parser = configparser.ConfigParser()
     parser.read([filename])
     config_dict = {}
 

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -186,7 +186,7 @@ class TestConfigurationNamespace:
 
 class TestGetNamespace:
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def mock_namespaces(self):
         with mock.patch.dict(config.configuration_namespaces):
             yield
@@ -205,7 +205,7 @@ class TestGetNamespace:
 
 class TestReload:
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def mock_namespaces(self):
         with mock.patch.dict(config.configuration_namespaces):
             yield
@@ -250,7 +250,7 @@ class TestReload:
 
 class TestValidateConfig:
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def patch_config(self):
         with mock.patch.dict(config.configuration_namespaces, clear=True):
             with testing.MockConfiguration():
@@ -361,7 +361,7 @@ class TestHasDuplicateKeys:
 
 class TestConfigurationWatcher:
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def setup_mocks_and_config_watcher(self):
         self.loader = mock.Mock()
         with mock.patch('staticconf.config.time') as self.mock_time:
@@ -529,7 +529,7 @@ class TestMTimeComparatorWithCompareFunc:
 
 class TestMD5Comparator:
 
-    @pytest.yield_fixture()
+    @pytest.fixture()
     def comparator(self):
         self.original_contents = b"abcdefghijkabcd"
         with tempfile.NamedTemporaryFile() as self.file:
@@ -654,7 +654,7 @@ class TestConfigFacadeAcceptance:
         tstamp = time.time() + mtime_seconds
         os.utime(self.file.name, (tstamp, tstamp))
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def patch_namespace(self):
         self.namespace = 'testing_namespace'
         with testing.MockConfiguration(namespace=self.namespace):
@@ -691,7 +691,7 @@ class TestConfigFacadeAcceptance:
 
 class TestBuildLoaderCallable:
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def patch_namespace(self):
         self.namespace = 'the_namespace'
         patcher = mock.patch('staticconf.config.get_namespace', autospec=True)

--- a/tests/getters_test.py
+++ b/tests/getters_test.py
@@ -11,7 +11,7 @@ from staticconf import getters, config, testing
 
 class TestBuildGetter:
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def teardown_proxies(self):
         with testing.MockConfiguration():
             yield
@@ -40,7 +40,7 @@ class TestBuildGetter:
 
 class TestNamespaceGetters:
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def teardown_proxies(self):
         self.namespace = 'the_test_namespace'
         with testing.MockConfiguration(namespace=self.namespace):
@@ -61,7 +61,7 @@ class TestNamespaceGetters:
 
 class TestProxyFactory:
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def patch_registries(self):
         patcher = mock.patch('staticconf.getters.register_value_proxy')
         with patcher as self.mock_register:

--- a/tests/loader_test.py
+++ b/tests/loader_test.py
@@ -22,7 +22,7 @@ class LoaderTestCase:
 
     content = None
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def mock_config(self):
         with mock.patch('staticconf.config') as self.mock_config:
             yield
@@ -126,7 +126,7 @@ class TestAutoConfiguration(LoaderTestCase):
     def setup_filename(self):
         self.filename = None
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def cleanup_file(self):
         yield
         if self.filename:
@@ -165,7 +165,7 @@ class TestPythonConfiguration(LoaderTestCase):
         }
     """)
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def teardown_module(self):
         yield
         self.remove_module()

--- a/tests/readers_test.py
+++ b/tests/readers_test.py
@@ -48,7 +48,7 @@ class TestNamespaceReader:
         'options': ['seven', 'stars']
     }
 
-    @pytest.yield_fixture(autouse=True)
+    @pytest.fixture(autouse=True)
     def patch_config(self):
         self.namespace = 'the_name'
         with testing.MockConfiguration(self.config, namespace=self.namespace):

--- a/tests/schema_test.py
+++ b/tests/schema_test.py
@@ -41,7 +41,7 @@ class ATestingSchema(metaclass=schema.SchemaMeta):
     options = schema.list_of_bool()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def meta_schema():
     with mock.patch('staticconf.schema.config', autospec=True) as mock_config:
         with mock.patch('staticconf.schema.getters',
@@ -82,7 +82,7 @@ class TestSchemaMeta:
             namespace, token, value_def.help)
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def testing_schema_namespace():
     conf = {
         'my.thing.one': '1',


### PR DESCRIPTION
## Problem

`tox -e py38` produces some noisy warnings:

```
PytestDeprecationWarning: @pytest.yield_fixture is deprecated.
  Use @pytest.fixture instead; they are the same.

DeprecationWarning: The SafeConfigParser class has been renamed to ConfigParser in Python 3.2. This alias will be removed in future versions. Use ConfigParser directly instead.

Unknown pytest.mark.acceptance - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
```

## Solution

Implement warning advice

## Action Plan
- [ ] Merge before #116 